### PR TITLE
The `Style/MethodMissingSuper` cop has been removed since it has been…

### DIFF
--- a/config/rubocop/style.yml
+++ b/config/rubocop/style.yml
@@ -21,7 +21,7 @@ Style/GuardClause:
 Style/MethodCalledOnDoEndBlock:
   Enabled: false
 
-Style/MethodMissingSuper:
+Lint/MissingSuper:
   Enabled: false
 
 Style/MissingRespondToMissing:


### PR DESCRIPTION
… superseded by `Lint/MissingSuper`