### PR TITLE
Revert "The `Style/MethodMissingSuper` cop has been removed since it has been…"

### DIFF
--- a/config/rubocop/style.yml
+++ b/config/rubocop/style.yml
@@ -21,7 +21,7 @@ Style/GuardClause:
 Style/MethodCalledOnDoEndBlock:
   Enabled: false
 
-Lint/MissingSuper:
+Style/MethodMissingSuper:
   Enabled: false
 
 Style/MissingRespondToMissing:


### PR DESCRIPTION
Reverts namely/namely_ruby_whiff#3